### PR TITLE
Setup mbgrader as a terminal command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ app/__pycache__/
 __pycache__/
 env/
 mbgrader.egg-info
+build/

--- a/README.md
+++ b/README.md
@@ -15,13 +15,9 @@ Setup environment:
     source env/bin/activate
     pip install --editable .
 
-Initialize the database:
-
-    flask init-db
-
 Run the development server:
 
-    flask run
+    mbgrader
 
 Open a browser and navigate to `http://127.0.0.1:5000/`. Create a new assignment by entering the corresponding folder name locating in the `submissions` folder. There is an example assignment called `example1`. mbgrader assumes the folder structure:
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from flask import Flask
 from flask.cli import with_appcontext
 import click
@@ -7,6 +8,7 @@ from flask_sqlalchemy import SQLAlchemy
 app = Flask(__name__)
 app.config.from_object(Config)
 db = SQLAlchemy(app)
+run = app.run
 
 from app import routes
 

--- a/app/run_server.py
+++ b/app/run_server.py
@@ -1,0 +1,17 @@
+from config import Config
+from flask import Flask
+
+import app
+from .commands import init_db
+
+def run_server():
+    """Helper function to automatically create a database and start a development server."""
+
+    db_path = Config.BASE_DIR / "app.db"
+    if db_path.exists():
+        print("Database found - reset by calling init-mbgrader-db")
+    else:
+        print("Database not found - creating...")
+        init_db(standalone_mode=False)
+
+    app.run()

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+from .config import Config

--- a/config/config.py
+++ b/config/config.py
@@ -1,7 +1,9 @@
+from pathlib import Path
 import os
 
-basedir = os.path.abspath(os.path.dirname(__file__))
+basedir = Path().cwd().resolve()
 
 class Config(object):
+    BASE_DIR = basedir
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -16,11 +16,19 @@ See `pyproject.toml` for required Python packages. Or create a virtual environme
 	source env/bin/activate
     pip install --editable .
 
-Initialize the SQLite database:
+Run the server:
 
-    flask init-db
+	mbgrader
 
-4. Note you only need to run `flask init-db` once for all. Running it a second time will erase previous grading records. Then the *mbgrader* is all set.
+### Setting up mbgrader for development
+
+If you wish to edit the source code and take advantage of development features like hot reloading, *mbgrader* can be launched with flask cli commands. After cloning the repository and activating the virtual environment:
+
+	flask init-db
+	flask run
+
+
+Note you only need to run `flask init-db` once for all. Running it a second time will erase previous grading records. Then the *mbgrader* is all set.
 
 ## Preparing Assignments
 
@@ -88,7 +96,7 @@ _2._ The above steps should be repeatedly done for each assignment before the ad
 
 1. Open terminal in the `./mbgrader/` folder, and enter the following command:
 
-		(env) $ flask run  #(or python/python3 -m flask run)
+		(env) $ mbgrader  # (or flask run)
 
 2. You are expected to see output below meaning the application is launched. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mbgrader"
 version = "0.1.0"
-requires-python = "==3.11.2"
 dependencies = [
     "flask == 2.3.2",
     "flask-sqlalchemy == 3.0.5",
@@ -14,5 +13,9 @@ dependencies = [
     "python-dotenv == 1.0.0",
 ]
 
-[tool.setuptools]
-packages = ["app"]
+[project.scripts]
+mbgrader = "app.run_server:run_server"
+init-mbgrader-db = "app.commands:init_db"
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
Added some helper functions for installing and running mbgrader as an independent package.

 - for development, `flask run` and `flask init-db` work as usual
 - Users can now clone the repo, cd into the directory, and call `pip install .`
 -  - once it's installed, you can simply call `mbgrader` to spin up a server (no init-db or python/flask calls needed!)